### PR TITLE
Cleanup tech debt, reduce number of requests

### DIFF
--- a/changelog/+apipath.changed.md
+++ b/changelog/+apipath.changed.md
@@ -1,0 +1,1 @@
+Made query utility accept API paths instead of internally defined identifiers

--- a/changelog/+apiret.changed.md
+++ b/changelog/+apiret.changed.md
@@ -1,0 +1,1 @@
+Made query utility return decoded API responses only

--- a/changelog/+exceptions.changed.md
+++ b/changelog/+exceptions.changed.md
@@ -1,0 +1,1 @@
+Made query utility communicate errors through exceptions to improve reliability and code quality

--- a/changelog/20.changed.md
+++ b/changelog/20.changed.md
@@ -1,0 +1,1 @@
+Stopped validating device names and sound names when posting a message since Pushover just ignores them. Invalid user names still result in an error.

--- a/changelog/21.fixed.md
+++ b/changelog/21.fixed.md
@@ -1,0 +1,1 @@
+Removed unused `api_version` parameter, made query util function respect `token` parameter, made state module respect `sound` parameter

--- a/changelog/22.changed.md
+++ b/changelog/22.changed.md
@@ -1,0 +1,1 @@
+BREAKING: Reordered parameters to `pushover_notify.post_message` to make it explicit `message` is the only absolutely required parameter

--- a/src/saltext/pushover/modules/pushover_notify.py
+++ b/src/saltext/pushover/modules/pushover_notify.py
@@ -30,7 +30,6 @@ def post_message(
     expire=None,
     retry=None,
     sound=None,
-    api_version=1,  # pylint: disable=unused-argument
     token=None,
 ):
     """

--- a/src/saltext/pushover/modules/pushover_notify.py
+++ b/src/saltext/pushover/modules/pushover_notify.py
@@ -21,11 +21,31 @@ def __virtual__():
     return __virtualname__
 
 
+def _resolve_token(token):
+    token = (
+        token
+        or __salt__["config.get"]("pushover.token")
+        or __salt__["config.get"]("pushover:token")
+    )
+    if not token:
+        raise SaltInvocationError("Pushover token is unavailable.")
+    return token
+
+
+def _resolve_user(user):
+    user = (
+        user or __salt__["config.get"]("pushover.user") or __salt__["config.get"]("pushover:user")
+    )
+    if not user:
+        raise SaltInvocationError("Pushover user key is unavailable.")
+    return user
+
+
 def post_message(
+    message,
+    title=None,
     user=None,
     device=None,
-    message=None,
-    title=None,
     priority=0,
     expire=None,
     retry=None,
@@ -33,32 +53,38 @@ def post_message(
     token=None,
 ):
     """
+    .. versionchanged:: 2.0.0
+        Parameters have been reordered.
+
+        ``device`` and ``sound`` parameters are no longer validated
+        to avoid unnecessary queries. Pushover defaults to all devices/the default sound in case the values are invalid.
+
     Send a message to a Pushover user or group.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' pushover.post_message user='uQiRzpo4DXghDmr9QzzfQu27cmVRsG' title='Message from Salt' message='Build is done'
+        salt '*' pushover.post_message 'Build is done'
+        salt '*' pushover.post_message user='uQiRzpo4DXghDmr9QzzfQu27cmVRsG' title='Hi' message='Build is done'
+        salt '*' pushover.post_message user='uQiRzpo4DXghDmr9QzzfQu27cmVRsG' title='Hi' message='Build is done' priority='2' expire='720' retry='5'
 
-        salt '*' pushover.post_message user='uQiRzpo4DXghDmr9QzzfQu27cmVRsG' title='Message from Salt' message='Build is done' priority='2' expire='720' retry='5'
+    message
+        Message text to send. Required.
+
+    title
+        Message title. Defaults to ``Message from Salt``.
 
     user
-        The user or group of users to send the message to. Must be a user/group ID (key),
+        User or group of users to send the message to. Must be a user/group ID (key),
         not a name or an email address.
         Required if not specified in the configuration.
 
     device
-        The name of the device to send the message to.
-
-    message
-        The message to send to the Pushover user or group. Required.
-
-    title
-        The message title to use. Defaults to ``Message from SaltStack``.
+        Name of the device to send the message to. Defaults to all devices of the user.
 
     priority
-        The priority of the message (integers between ``-2`` and ``2``).
+        Message priority (integers between ``-2`` and ``2``).
         Defaults to ``0``.
 
         .. note::
@@ -74,63 +100,73 @@ def post_message(
         Repeat the notification after this amount of seconds. Minimum: ``30``.
 
     sound
-        The `notification sound <https://pushover.net/api#sounds>`_ to play.
+        `Notification sound <https://pushover.net/api#sounds>`_ to play. Defaults to user default.
 
     token
-        The authentication token to use for the Pushover API.
+        Pushover API token.
         Required if not specified in the configuration.
     """
-
-    if not token:
-        token = __salt__["config.get"]("pushover.token") or __salt__["config.get"]("pushover:token")
-        if not token:
-            raise SaltInvocationError("Pushover token is unavailable.")
-
-    if not user:
-        user = __salt__["config.get"]("pushover.user") or __salt__["config.get"]("pushover:user")
-        if not user:
-            raise SaltInvocationError("Pushover user key is unavailable.")
-
-    if not message:
-        raise SaltInvocationError('Required parameter "message" is missing.')
-
-    if priority not in range(-2, 3):
-        raise SaltInvocationError(
-            f"Invalid priority {priority}. Needs to be an integer between -2 and 2 (inclusive)"
-        )
-
-    if priority == 2 and not (expire and retry):
-        raise SaltInvocationError(
-            "Emergency messages require `expire` and `retry` parameters to be set"
-        )
-
-    if retry and retry < 30:
-        raise SaltInvocationError("`retry` needs to be at least 30 (seconds)")
-
-    pushover.validate_user(user, token, device, context=__context__, opts=__opts__)
-
-    if not title:
-        title = "Message from SaltStack"
-
-    parameters = {}
-    parameters["user"] = user
-    if device is not None:
-        parameters["device"] = device
-    parameters["title"] = title
-    parameters["priority"] = priority
-    if expire is not None:
-        parameters["expire"] = expire
-    if retry is not None:
-        parameters["retry"] = retry
-    parameters["message"] = message
-
-    if sound and pushover.validate_sound(sound, token, context=__context__, opts=__opts__):
-        parameters["sound"] = sound
-
-    pushover.query(
-        endpoint="messages",
-        token=token,
-        data=parameters,
+    token, user = _resolve_token(token), _resolve_user(user)
+    return pushover.post_message(
+        message,
+        user,
+        token,
+        title=title,
+        device=device,
+        priority=priority,
+        expire=expire,
+        retry=retry,
+        sound=sound,
         opts=__opts__,
     )
-    return True
+
+
+def validate_user(user=None, device=None, token=None):
+    """
+    .. versionadded:: 2.0.0
+
+    Validate the resolved user and device combination.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pushover.validate_user
+        salt '*' pushover.validate_user device=foobar
+        salt '*' pushover.post_message user='uQiRzpo4DXghDmr9QzzfQu27cmVRsG' device=foobar
+
+    user
+        User to validate. Defaults to configured user.
+
+    device
+        Device of ``user`` to validate. If unspecified, ensures ``user`` has any registered device.
+
+    token
+        Pushover API token.
+        Required if not specified in the configuration.
+    """
+    token, user = _resolve_token(token), _resolve_user(user)
+    return pushover.validate_user(user, token, device, context=__context__, opts=__opts__)
+
+
+def validate_sound(sound, token=None):
+    """
+    .. versionadded:: 2.0.0
+
+    Validate a sound exists. Can only check official sounds.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pushover.validate_sound bike
+
+    sound
+        Sound to validate.
+
+    token
+        Pushover API token.
+        Required if not specified in the configuration.
+    """
+    token = _resolve_token(token)
+    return pushover.validate_sound(sound, token, context=__context__, opts=__opts__)

--- a/src/saltext/pushover/modules/pushover_notify.py
+++ b/src/saltext/pushover/modules/pushover_notify.py
@@ -7,13 +7,13 @@ Send notifications via `Pushover <https://pushover.net>`_.
 """
 
 import logging
-import urllib.parse
 
 from salt.exceptions import SaltInvocationError
 
-import saltext.pushover.utils.pushover
+from saltext.pushover.utils import pushover
 
 log = logging.getLogger(__name__)
+
 __virtualname__ = "pushover"
 
 
@@ -107,9 +107,7 @@ def post_message(
     if retry and retry < 30:
         raise SaltInvocationError("`retry` needs to be at least 30 (seconds)")
 
-    user_validate = saltext.pushover.utils.pushover.validate_user(user, device, token)
-    if not user_validate["result"]:
-        return user_validate
+    pushover.validate_user(user, token, device, context=__context__, opts=__opts__)
 
     if not title:
         title = "Message from SaltStack"
@@ -118,7 +116,6 @@ def post_message(
     parameters["user"] = user
     if device is not None:
         parameters["device"] = device
-    parameters["token"] = token
     parameters["title"] = title
     parameters["priority"] = priority
     if expire is not None:
@@ -127,17 +124,13 @@ def post_message(
         parameters["retry"] = retry
     parameters["message"] = message
 
-    if sound and saltext.pushover.utils.pushover.validate_sound(sound, token)["res"]:
+    if sound and pushover.validate_sound(sound, token, context=__context__, opts=__opts__):
         parameters["sound"] = sound
 
-    result = saltext.pushover.utils.pushover.query(
-        function="message",
-        method="POST",
-        header_dict={"Content-Type": "application/x-www-form-urlencoded"},
-        data=urllib.parse.urlencode(parameters),
+    pushover.query(
+        endpoint="messages",
+        token=token,
+        data=parameters,
         opts=__opts__,
     )
-
-    if result["res"]:
-        return True
-    return result
+    return True

--- a/src/saltext/pushover/returners/pushover_returner.py
+++ b/src/saltext/pushover/returners/pushover_returner.py
@@ -86,54 +86,6 @@ def _get_options(ret=None):
     return _options
 
 
-def _post_message(
-    user,
-    device,
-    message,
-    title,
-    priority,
-    expire,
-    retry,
-    sound,
-    token=None,
-):
-    """
-    Send a message to a Pushover user or group.
-
-    :param user:        The user or group to send to, must be key of user or group not email address.
-    :param message:     The message to send to the Pushover user or group.
-    :param title:       Specify who the message is from.
-    :param priority     The priority of the message, defaults to 0.
-    :param notify:      Whether to notify the room, default: False.
-    :param token:       The Pushover token, if not specified in the configuration.
-    :return:            Boolean if message was sent successfully.
-    """
-
-    pushover.validate_user(user, token, device=device, context=__context__, opts=__opts__)
-
-    parameters = {}
-    parameters["user"] = user
-    if device is not None:
-        parameters["device"] = device
-    parameters["title"] = title
-    parameters["priority"] = priority
-    if expire is not None:
-        parameters["expire"] = expire
-    if retry is not None:
-        parameters["retry"] = retry
-    parameters["message"] = message
-
-    if sound and pushover.validate_sound(sound, token):
-        parameters["sound"] = sound
-
-    return pushover.query(
-        "messages",
-        token=token,
-        data=parameters,
-        opts=__opts__,
-    )
-
-
 def returner(ret):
     """
     Send a Pushover notification with the return data.
@@ -156,12 +108,6 @@ def returner(ret):
     if not user:
         raise SaltInvocationError("Pushover user key is unavailable.")
 
-    if priority and priority == 2:
-        if not expire and not retry:
-            raise SaltInvocationError(
-                "Priority 2 requires pushover.expire and pushover.retry options."
-            )
-
     # pylint: disable=consider-using-f-string
     message = "id: {}\r\nfunction: {}\r\nfunction args: {}\r\njid: {}\r\nreturn: {}\r\n".format(
         ret.get("id"),
@@ -172,16 +118,17 @@ def returner(ret):
     )
 
     try:
-        res = _post_message(
-            user=user,
-            device=device,
-            message=message,
+        res = pushover.post_message(
+            message,
+            user,
+            token,
             title=title,
+            device=device,
             priority=priority,
             expire=expire,
             retry=retry,
             sound=sound,
-            token=token,
+            opts=__opts__,
         )
         log.debug("Pushover result: %s", res)
     except CommandExecutionError as err:

--- a/src/saltext/pushover/returners/pushover_returner.py
+++ b/src/saltext/pushover/returners/pushover_returner.py
@@ -29,12 +29,12 @@ To override individual configuration items during the call, pass
 
 import logging
 import pprint
-import urllib.parse
 
 import salt.returners
+from salt.exceptions import CommandExecutionError
 from salt.exceptions import SaltInvocationError
 
-import saltext.pushover.utils.pushover
+from saltext.pushover.utils import pushover
 
 log = logging.getLogger(__name__)
 
@@ -109,15 +109,12 @@ def _post_message(
     :return:            Boolean if message was sent successfully.
     """
 
-    user_validate = saltext.pushover.utils.pushover.validate_user(user, device, token)
-    if not user_validate["result"]:
-        return user_validate
+    pushover.validate_user(user, token, device=device, context=__context__, opts=__opts__)
 
     parameters = {}
     parameters["user"] = user
     if device is not None:
         parameters["device"] = device
-    parameters["token"] = token
     parameters["title"] = title
     parameters["priority"] = priority
     if expire is not None:
@@ -126,20 +123,15 @@ def _post_message(
         parameters["retry"] = retry
     parameters["message"] = message
 
-    if sound:
-        sound_validate = saltext.pushover.utils.pushover.validate_sound(sound, token)
-        if sound_validate["res"]:
-            parameters["sound"] = sound
+    if sound and pushover.validate_sound(sound, token):
+        parameters["sound"] = sound
 
-    result = saltext.pushover.utils.pushover.query(
-        function="message",
-        method="POST",
-        header_dict={"Content-Type": "application/x-www-form-urlencoded"},
-        data=urllib.parse.urlencode(parameters),
+    return pushover.query(
+        "messages",
+        token=token,
+        data=parameters,
         opts=__opts__,
     )
-
-    return result
 
 
 def returner(ret):
@@ -179,18 +171,18 @@ def returner(ret):
         pprint.pformat(ret.get("return")),
     )
 
-    result = _post_message(
-        user=user,
-        device=device,
-        message=message,
-        title=title,
-        priority=priority,
-        expire=expire,
-        retry=retry,
-        sound=sound,
-        token=token,
-    )
-
-    log.debug("pushover result %s", result)
-    if not result["res"]:
-        log.info("Error: %s", result["message"])
+    try:
+        res = _post_message(
+            user=user,
+            device=device,
+            message=message,
+            title=title,
+            priority=priority,
+            expire=expire,
+            retry=retry,
+            sound=sound,
+            token=token,
+        )
+        log.debug("Pushover result: %s", res)
+    except CommandExecutionError as err:
+        log.info("Error: %s", err)

--- a/src/saltext/pushover/returners/pushover_returner.py
+++ b/src/saltext/pushover/returners/pushover_returner.py
@@ -55,7 +55,6 @@ def _get_options(ret=None):
         "token": "token",
         "priority": "priority",
         "title": "title",
-        "api_version": "api_version",
         "expire": "expire",
         "retry": "retry",
         "sound": "sound",
@@ -69,7 +68,6 @@ def _get_options(ret=None):
         "token": "token",
         "priority": "priority",
         "title": "title",
-        "api_version": "api_version",
         "expire": "expire",
         "retry": "retry",
         "sound": "sound",
@@ -97,7 +95,6 @@ def _post_message(
     expire,
     retry,
     sound,
-    api_version=1,  # pylint: disable=unused-argument
     token=None,
 ):
     """
@@ -107,7 +104,6 @@ def _post_message(
     :param message:     The message to send to the Pushover user or group.
     :param title:       Specify who the message is from.
     :param priority     The priority of the message, defaults to 0.
-    :param api_version: The Pushover API version, if not specified in the configuration.
     :param notify:      Whether to notify the room, default: False.
     :param token:       The Pushover token, if not specified in the configuration.
     :return:            Boolean if message was sent successfully.

--- a/src/saltext/pushover/states/pushover.py
+++ b/src/saltext/pushover/states/pushover.py
@@ -40,7 +40,6 @@ def post_message(
     expire=None,
     retry=None,
     sound=None,  # pylint: disable=unused-argument
-    api_version=1,  # pylint: disable=unused-argument
     token=None,
 ):
     """

--- a/src/saltext/pushover/states/pushover.py
+++ b/src/saltext/pushover/states/pushover.py
@@ -24,6 +24,9 @@ Example
 __virtualname__ = "pushover"
 
 
+from salt.exceptions import CommandExecutionError
+
+
 def __virtual__():
     if "pushover.post_message" in __salt__:
         return __virtualname__
@@ -111,21 +114,22 @@ def post_message(
         ret["comment"] = f"Pushover message is missing: {message}"
         return ret
 
-    result = __salt__["pushover.post_message"](
-        user=user,
-        message=message,
-        title=title,
-        device=device,
-        priority=priority,
-        expire=expire,
-        retry=retry,
-        token=token,
-    )
-
-    if result:
+    try:
+        __salt__["pushover.post_message"](
+            user=user,
+            message=message,
+            title=title,
+            device=device,
+            priority=priority,
+            expire=expire,
+            retry=retry,
+            token=token,
+        )
+    except CommandExecutionError as err:
+        ret["result"] = False
+        ret["comment"] = "Failed to send message '{name}'! Error: " + str(err)
+    else:
         ret["result"] = True
         ret["comment"] = f"Sent message: {name}"
-    else:
-        ret["comment"] = f"Failed to send message: {name}"
 
     return ret

--- a/src/saltext/pushover/states/pushover.py
+++ b/src/saltext/pushover/states/pushover.py
@@ -35,14 +35,14 @@ def __virtual__():
 
 def post_message(
     name,
+    message,
+    title=None,
     user=None,
     device=None,
-    message=None,
-    title=None,
     priority=0,
     expire=None,
     retry=None,
-    sound=None,  # pylint: disable=unused-argument
+    sound=None,
     token=None,
 ):
     """
@@ -59,26 +59,27 @@ def post_message(
             - priority: -1
             - expire: 3600
             - retry: 5
+            - message: 'This state was executed successfully.'
 
     name
         The name of the state. Irrelevant.
 
+    message
+        Message text to send. Required.
+
+    title
+        Message title. Defaults to ``Message from Salt``.
+
     user
-        The user or group of users to send the message to. Must be a user/group ID (key),
+        User or group of users to send the message to. Must be a user/group ID (key),
         not a name or an email address.
         Required if not specified in the configuration.
 
-    message
-        The message to send to the Pushover user or group. Required.
-
-    title
-        The message title to use.
-
     device
-        The name of the device to send the message to.
+        Name of the device to send the message to. Defaults to all devices of the user.
 
     priority
-        The priority of the message (integers between ``-2`` and ``2``).
+        Message priority (integers between ``-2`` and ``2``).
         Defaults to ``0``.
 
         .. note::
@@ -93,8 +94,11 @@ def post_message(
     retry
         Repeat the notification after this amount of seconds. Minimum: ``30``.
 
+    sound
+        `Notification sound <https://pushover.net/api#sounds>`_ to play. Defaults to user default.
+
     token
-        The authentication token to use for the Pushover API.
+        Pushover API key.
         Required if not specified in the configuration.
     """
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
@@ -104,30 +108,21 @@ def post_message(
         ret["result"] = None
         return ret
 
-    if not user:
-        user = __salt__["config.get"]("pushover.user") or __salt__["config.get"]("pushover:user")
-        if not user:
-            ret["comment"] = f"Pushover user is missing: {user}"
-            return ret
-
-    if not message:
-        ret["comment"] = f"Pushover message is missing: {message}"
-        return ret
-
     try:
         __salt__["pushover.post_message"](
-            user=user,
-            message=message,
+            message,
             title=title,
+            user=user,
             device=device,
             priority=priority,
             expire=expire,
             retry=retry,
+            sound=sound,
             token=token,
         )
     except CommandExecutionError as err:
         ret["result"] = False
-        ret["comment"] = "Failed to send message '{name}'! Error: " + str(err)
+        ret["comment"] = f"Failed to send message '{name}'! Error: " + str(err)
     else:
         ret["result"] = True
         ret["comment"] = f"Sent message: {name}"

--- a/src/saltext/pushover/utils/pushover.py
+++ b/src/saltext/pushover/utils/pushover.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 def query(
     function,
-    token=None,  # pylint: disable=unused-argument
+    token=None,
     api_version="1",
     method="POST",
     header_dict=None,
@@ -48,6 +48,13 @@ def query(
 
     if not query_params:
         query_params = {}
+
+    if token:
+        if method == "GET":
+            query_params["token"] = token
+        else:
+            data = data or {}
+            data["token"] = token
 
     decode = True
     if method == "DELETE":

--- a/src/saltext/pushover/utils/pushover.py
+++ b/src/saltext/pushover/utils/pushover.py
@@ -2,53 +2,99 @@
 Utility functions for interacting with the Pushover API.
 """
 
-import http.client
 import logging
-from urllib.parse import urlencode
-from urllib.parse import urljoin
 
 import salt.utils.http
+import salt.utils.json
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
+API_URL = "https://api.pushover.net"
+
+
+class PushoverAPIError(CommandExecutionError):
+    """
+    Generic exception to render Pushover API errors.
+    """
+
+    status: int
+    res: dict
+    raw: str | None
+
+    def __init__(self, status: int, res: dict | None = None, raw: str | None = None):
+        res = res or {}
+        self.status = status
+        self.res = res
+        self.raw = raw
+
+        msg = f"Pushover API Error (HTTP {status}): "
+        if "errors" in res:
+            msg += "; ".join(res["errors"])
+        elif self.raw:
+            msg += self.raw
+        else:
+            msg += "(no further description)"
+        super().__init__(msg)
+
 
 def query(
-    function,
-    token=None,
-    api_version="1",
+    endpoint,
     method="POST",
-    header_dict=None,
+    *,
     data=None,
     query_params=None,
+    token=None,
+    api_version="1",
+    header_dict=None,
     opts=None,
 ):
     """
+    .. versionchanged:: 2.0.0
+        * Parameters have been reordered.
+        * Uses JSON request bodies by default.
+        * Errors result in exceptions.
+        * Returns the decoded response data only.
+
     Query the Pushover API.
 
-    :param token:       The Pushover API key. **Ignored**. FIXME
-    :param api_version: The Pushover API version to use, defaults to version 1. (There is only version 1 FIXME).
-    :param function:    The Pushover API function to perform.
-    :param method:      The HTTP method, e.g. GET or POST.
-    :param data:        The data to be sent for POST method.
-    :return:            The json response from the API call or False.
+    endpoint
+        API endpoint to query (without ``.json`` suffix), e.g. ``messages``.
+
+        .. versionchanged:: 2.0.0
+            Previously, the first parameter was an internally defined identifier.
+            This accepts all API paths.
+
+    method
+        HTTP method. Defaults to ``POST``.
+
+    data
+        Request body data.
+
+        .. versionchanged:: 2.0.0
+            Automatically dumped to JSON, unless the ``Content-Type`` header
+            is set explicitly in ``header_dict``.
+
+    query_params
+        URI query parameter dictionary.
+
+    token
+        Pushover API token.
+        Optional if already specified in ``data`` or ``query_params``,
+        depending on the method. Overrides them.
+
+    api_version
+        API version. Used for building query URI. Defaults to ``1``.
+
+    header_dict
+        HTTP request headers to add.
+
+    opts
+        Pass through ``__opts__`` to respect Salt HTTP configuration.
     """
+    query_params = query_params or {}
 
-    ret = {"message": "", "res": True}
-
-    pushover_functions = {
-        "message": {"request": "messages.json", "response": "status"},
-        "validate_user": {"request": "users/validate.json", "response": "status"},
-        "validate_sound": {"request": "sounds.json", "response": "status"},
-    }
-
-    api_url = "https://api.pushover.net"
-    base_url = urljoin(api_url, api_version + "/")
-    path = pushover_functions.get(function).get("request")
-    url = urljoin(base_url, path, False)
-
-    if not query_params:
-        query_params = {}
-
+    decode = method != "DELETE"
     if token:
         if method == "GET":
             query_params["token"] = token
@@ -56,12 +102,14 @@ def query(
             data = data or {}
             data["token"] = token
 
-    decode = True
-    if method == "DELETE":
-        decode = False
+    header_dict = header_dict or {}
+    if method != "GET" and "Content-Type" not in header_dict:
+        header_dict["Content-Type"] = "application/json"
+        if data:
+            data = salt.utils.json.dumps(data)
 
     result = salt.utils.http.query(
-        url,
+        f"{API_URL}/{api_version}/{endpoint}.json",
         method,
         params=query_params,
         data=data,
@@ -70,89 +118,101 @@ def query(
         decode_type="json",
         text=True,
         status=True,
-        cookies=True,
-        persist_session=True,
         opts=opts,
     )
+    if decode and "dict" not in result:
+        # Salt does not decode the body if the status indicates an error
+        try:
+            result["dict"] = salt.utils.json.loads(result["body"])
+        except ValueError:
+            result["dict"] = {}
 
-    if result.get("status", None) == http.client.OK:
-        response = pushover_functions.get(function).get("response")
-        if response in result and result[response] == 0:
-            ret["res"] = False
-        ret["message"] = result
-        return ret
-    try:
-        if "response" in result and result[response] == 0:
-            ret["res"] = False
-        ret["message"] = result
-    except ValueError:
-        ret["res"] = False
-        ret["message"] = result
-    return ret
+    if result["status"] >= 400:
+        raise PushoverAPIError(result["status"], result.get("dict"), result.get("text"))
+    if decode:
+        return result["dict"]
+    return result["text"]
 
 
-def validate_sound(sound, token):
+def validate_sound(sound, token, *, context=None, opts=None):
     """
     Validate that a specified sound value exists.
 
-    :param sound:       The sound that we want to verify
-    :param token:       The Pushover token.
+    sound
+        Sound to verify
+
+    token
+        Pushover API token
+
+    context
+        Pass through ``__context__`` to allow caching.
+
+        .. versionadded:: 2.0.0
+
+    opts
+        Pass through ``__opts__`` to respect Salt HTTP configuration.
+
+        .. versionadded:: 2.0.0
     """
-    ret = {"message": "Sound is invalid", "res": False}
-    parameters = {}
-    parameters["token"] = token
-
-    response = query(function="validate_sound", method="GET", query_params=parameters)
-
-    if response["res"]:
-        if "message" in response:
-            _message = response.get("message", "")
-            if "status" in _message:
-                if _message.get("dict", {}).get("status", "") == 1:
-                    sounds = _message.get("dict", {}).get("sounds", "")
-                    if sound in sounds:
-                        ret["message"] = f"Valid sound {sound}."
-                        ret["res"] = True
-                    else:
-                        ret["message"] = f"Warning: {sound} not a valid sound."
-                        ret["res"] = False
-                else:
-                    ret["message"] = "".join(_message.get("dict", {}).get("errors"))
-    return ret
+    context = context or {}
+    if "pushover_sounds" in context:
+        sounds = context["pushover_sounds"]
+    else:
+        sounds = query("sounds", "GET", token=token, opts=opts)["sounds"]
+        context["pushover_sounds"] = sounds
+    return sound in sounds
 
 
-def validate_user(user, device, token):
+def validate_user(user, token, device=None, *, context=None, opts=None):
     """
     Validate that a user/group ID (key) exists and has at least one active device.
     If ``device`` is not falsy, additionally validate that the device exists in the account.
 
-    :param user:        The user or group name, either will work.
-    :param device:      The device for the user.
-    :param token:       The Pushover token.
+    user
+        User or group name to validate. Required.
+
+    token
+        Pushover API token. Required.
+
+    device
+        Optional device for ``user`` to validate.
+        If unspecified, checks whether any device is available.
+
+    context
+        Pass through ``__context__`` to allow caching.
+
+        .. versionadded:: 2.0.0
+
+    opts
+        Pass through ``__opts__`` to respect Salt HTTP configuration.
+
+        .. versionadded:: 2.0.0
     """
-    res = {"message": "User key is invalid", "result": False}
+    ckey = (user, token, device)
+    context = context or {}
+    if ckey in context:
+        return True
 
-    parameters = {}
-    parameters["user"] = user
-    parameters["token"] = token
+    payload = {"user": user}
     if device:
-        parameters["device"] = device
+        payload["device"] = device
 
-    response = query(
-        function="validate_user",
-        method="POST",
-        header_dict={"Content-Type": "application/x-www-form-urlencoded"},
-        data=urlencode(parameters),
-    )
+    try:
+        query(
+            endpoint="users/validate",
+            data=payload,
+            token=token,
+            opts=opts,
+        )
+    except PushoverAPIError as err:
+        if "invalid" in err.res.get("user", ""):
+            raise CommandExecutionError(f"Pushover: Invalid user '{user}'") from err
+        if "invalid" in err.res.get("device", ""):
+            raise CommandExecutionError(
+                f"Pushover: Invalid device '{device}' for user '{user}'"
+            ) from err
+        raise
 
-    if response["res"]:
-        if "message" in response:
-            _message = response.get("message", "")
-            if "status" in _message:
-                if _message.get("dict", {}).get("status", None) == 1:
-                    res["result"] = True
-                    res["message"] = "User key is valid."
-                else:
-                    res["result"] = False
-                    res["message"] = "".join(_message.get("dict", {}).get("errors"))
-    return res
+    # Only cache successful lookups to avoid false negatives
+    context[ckey] = True
+    return True

--- a/src/saltext/pushover/utils/pushover.py
+++ b/src/saltext/pushover/utils/pushover.py
@@ -7,6 +7,7 @@ import logging
 import salt.utils.http
 import salt.utils.json
 from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
 
@@ -216,3 +217,94 @@ def validate_user(user, token, device=None, *, context=None, opts=None):
     # Only cache successful lookups to avoid false negatives
     context[ckey] = True
     return True
+
+
+def post_message(
+    message,
+    user,
+    token,
+    *,
+    title=None,
+    device=None,
+    priority=0,
+    expire=None,
+    retry=None,
+    sound=None,
+    opts=None,
+):
+    """
+    .. versionadded:: 2.0.0
+
+    Send a message to a Pushover user or group.
+
+    message
+        Message text to send. Required.
+
+    user
+        User or group of users to send the message to. Must be a user/group ID (key),
+        not a name or an email address. Required.
+
+    token
+        Pushover API token. Required.
+
+    title
+        Message title. Defaults to ``Message from Salt``.
+
+    device
+        Name of the device to send the message to. Defaults to all devices of the user.
+
+    priority
+        Message priority (integers between ``-2`` and ``2``).
+        Defaults to ``0``.
+
+        .. note::
+
+            Emergency priority (``2``) requires ``expire`` and ``retry`` parameters
+            to be set.
+
+    expire
+        Stop notifying the user after the specified amount of seconds.
+        The message is still shown after expiry.
+
+    retry
+        Repeat the notification after this amount of seconds. Minimum: ``30``.
+
+    sound
+        `Notification sound <https://pushover.net/api#sounds>`_ to play. Defaults to user default.
+
+    opts
+        Pass through ``__opts__`` to respect Salt HTTP configuration.
+    """
+    if priority not in range(-2, 3):
+        raise SaltInvocationError(
+            f"Invalid priority {priority}. Needs to be an integer between -2 and 2 (inclusive)"
+        )
+    if priority == 2 and not (expire and retry):
+        raise SaltInvocationError(
+            "Emergency messages require `expire` and `retry` parameters to be set"
+        )
+
+    if retry and retry < 30:
+        raise SaltInvocationError("`retry` needs to be at least 30 (seconds)")
+
+    payload = {
+        "user": user,
+        "title": title or "Message from Salt",
+        "priority": priority,
+        "message": message,
+    }
+    if device is not None:
+        payload["device"] = device
+    if expire is not None:
+        payload["expire"] = expire
+    if retry is not None:
+        payload["retry"] = retry
+    if sound:
+        payload["sound"] = sound
+
+    return query(
+        endpoint="messages",
+        token=token,
+        data=payload,
+        opts=opts,
+    )

--- a/tests/unit/modules/test_pushover_notify.py
+++ b/tests/unit/modules/test_pushover_notify.py
@@ -1,0 +1,174 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from salt.exceptions import CommandExecutionError
+
+import saltext.pushover.modules.pushover_notify as po
+
+
+def _config_get(conf, *_args, **_kwargs):
+    return conf
+
+
+@pytest.fixture
+def configure_loader_modules(context):
+    return {
+        po: {
+            "__salt__": {"config.get": _config_get},
+            "__context__": context,
+        },
+    }
+
+
+@pytest.fixture
+def context():
+    return {"keep dict ref": True}
+
+
+@pytest.fixture
+def http_query():
+    with patch("salt.utils.http.query", autospec=True) as query:
+        query.return_value = {"status": 200, "dict": {}, "text": "{}"}
+        yield query
+
+
+def test_post_message_bare(http_query):
+    po.post_message("Hi")
+    http_query.assert_called_once()
+    args, kwargs = http_query.call_args
+    assert args[0] == "https://api.pushover.net/1/messages.json"
+    assert args[1] == "POST"
+    data = json.loads(kwargs["data"])
+    assert data == {
+        "user": "pushover.user",
+        "priority": 0,
+        "message": "Hi",
+        "title": "Message from Salt",
+        "token": "pushover.token",
+    }
+
+
+def test_post_message_all(http_query):
+    po.post_message(
+        "Hi",
+        title="title",
+        user="user",
+        device="device",
+        priority=1,
+        expire=180,
+        retry=33,
+        sound="bike",
+        token="token",
+    )
+    http_query.assert_called_once()
+    data = json.loads(http_query.call_args[1]["data"])
+    assert data == {
+        "user": "user",
+        "title": "title",
+        "priority": 1,
+        "message": "Hi",
+        "device": "device",
+        "expire": 180,
+        "retry": 33,
+        "sound": "bike",
+        "token": "token",
+    }
+
+
+def test_validate_user_user_ok(http_query):
+    po.validate_user()
+    args, kwargs = http_query.call_args
+    assert args[0] == "https://api.pushover.net/1/users/validate.json"
+    assert args[1] == "POST"
+    data = json.loads(kwargs["data"])
+    data = json.loads(http_query.call_args[1]["data"])
+    assert data == {"user": "pushover.user", "token": "pushover.token"}
+
+
+def test_validate_user_user_fail(http_query):
+    prev_ret = http_query.return_value
+    http_query.return_value = {
+        "status": 400,
+        "error": "HTTP 400: Bad Request",
+        "body": '{"user":"invalid","errors":["user key is invalid"],"status":0,"request":"6aa7ec75-11a0-426a-88a4-a71437519c46"}',
+        "dict": {
+            "user": "invalid",
+            "errors": ["user key is invalid"],
+            "status": 0,
+            "request": "6aa7ec75-11a0-426a-88a4-a71437519c46",
+        },
+    }
+    with pytest.raises(CommandExecutionError, match=".*Invalid user"):
+        po.validate_user()
+    data = json.loads(http_query.call_args[1]["data"])
+    assert data == {"user": "pushover.user", "token": "pushover.token"}
+    http_query.return_value = prev_ret
+    # Check that we don't cache negative results to keep false negatives low
+    po.validate_user()
+
+
+def test_validate_user_device_ok(http_query):
+    po.validate_user(user="foo", token="token", device="device")
+    data = json.loads(http_query.call_args[1]["data"])
+    assert data == {"user": "foo", "token": "token", "device": "device"}
+
+
+def test_validate_user_device_fail(http_query):
+    http_query.return_value = {
+        "status": 400,
+        "error": "HTTP 400: Bad Request",
+        "body": '{"device":"invalid for this user","group":0,"licenses":["iOS"],"errors":["device name is not valid for user"],"status":0,"request":"19c385f6-8a7d-462f-a531-33d3f3d4bbbe"}',
+        "dict": {
+            "device": "invalid for this user",
+            "group": 0,
+            "licenses": ["iOS"],
+            "errors": ["device name is not valid for user"],
+            "status": 0,
+            "request": "19c385f6-8a7d-462f-a531-33d3f3d4bbbe",
+        },
+    }
+    with pytest.raises(CommandExecutionError, match=".*Invalid device.*"):
+        po.validate_user()
+    data = json.loads(http_query.call_args[1]["data"])
+    assert data == {"user": "pushover.user", "token": "pushover.token"}
+
+
+def test_validate_sound_ok(http_query, context):
+    http_query.return_value = {
+        "status": 200,
+        "dict": {"sounds": {"bike": "description", "foo": "other"}},
+    }
+    po.validate_sound("bike")
+    http_query.assert_called_once()
+    args, kwargs = http_query.call_args
+    assert args[0] == "https://api.pushover.net/1/sounds.json"
+    assert args[1] == "GET"
+    assert kwargs["params"] == {"token": "pushover.token"}
+    po.validate_sound("bike")
+    http_query.assert_called_once()
+    po.validate_sound("other")
+    http_query.assert_called_once()
+    context["pushover_sounds"]["new"] = "fake"
+    po.validate_sound("new")
+    http_query.assert_called_once()
+
+
+def test_validate_sound_err(http_query, context):
+    http_query.return_value = {
+        "status": 200,
+        "dict": {"sounds": {"bike": "description", "foo": "other"}},
+    }
+    po.validate_sound("bike")
+    http_query.assert_called_once()
+    args, kwargs = http_query.call_args
+    assert args[0] == "https://api.pushover.net/1/sounds.json"
+    assert args[1] == "GET"
+    assert kwargs["params"] == {"token": "pushover.token"}
+    po.validate_sound("bike")
+    http_query.assert_called_once()
+    po.validate_sound("other")
+    http_query.assert_called_once()
+    context["pushover_sounds"]["new"] = "fake"
+    po.validate_sound("new")
+    http_query.assert_called_once()

--- a/tests/unit/returners/test_pushover_returner.py
+++ b/tests/unit/returners/test_pushover_returner.py
@@ -1,0 +1,82 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+import saltext.pushover.returners.pushover_returner as po
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        po: {},
+    }
+
+
+@pytest.fixture(autouse=True)
+def config():
+    conf = {
+        "title": "title",
+        "user": "user",
+        "device": "device",
+        "priority": 1,
+        "expire": 180,
+        "retry": 33,
+        "sound": "bike",
+        "token": "token",
+    }
+    with patch(
+        "saltext.pushover.returners.pushover_returner._get_options", autospec=True
+    ) as getopts:
+        getopts.return_value = conf
+        yield getopts
+
+
+@pytest.fixture
+def http_query():
+    with patch("salt.utils.http.query", autospec=True) as query:
+        query.return_value = {"status": 200, "dict": {}, "text": "{}"}
+        yield query
+
+
+def test_returner(http_query):
+    ret = {
+        "id": "id",
+        "fun": "fun",
+        "fun_args": [],
+        "jid": "jid",
+        "return": {"foo": True},
+    }
+    po.returner(ret)
+    http_query.assert_called_once()
+    data = json.loads(http_query.call_args[1]["data"])
+    exp_msg = (
+        "id: id\r\nfunction: fun\r\nfunction args: []\r\njid: jid\r\nreturn: {'foo': True}\r\n"
+    )
+    assert data == {
+        "user": "user",
+        "title": "title",
+        "priority": 1,
+        "message": exp_msg,
+        "device": "device",
+        "expire": 180,
+        "retry": 33,
+        "sound": "bike",
+        "token": "token",
+    }
+
+
+def test_returner_err_no_crash(http_query):
+    """
+    Ensure the returner does not leak exceptions from the utils module
+    """
+    http_query.return_value = {"status": 500, "body": ""}
+    ret = {
+        "id": "id",
+        "fun": "fun",
+        "fun_args": [],
+        "jid": "jid",
+        "return": {"foo": True},
+    }
+    po.returner(ret)
+    http_query.assert_called_once()

--- a/tests/unit/states/test_pushover.py
+++ b/tests/unit/states/test_pushover.py
@@ -29,7 +29,7 @@ def test_mode(request):
 
 def test_pushover_state(test_mode, post_message):
     message = "Chaos is a ladder"
-    ret = po.post_message("event", "user", message=message)
+    ret = po.post_message(name="event", message=message, user="user")
     assert isinstance(ret, dict)
     assert ret["name"] == "event"
     assert not ret["changes"]
@@ -43,12 +43,13 @@ def test_pushover_state(test_mode, post_message):
         assert ret["result"] is True
         assert ret["comment"].startswith("Sent message")
         post_message.assert_called_once_with(
-            user="user",
-            message=message,
+            message,
             title=None,
+            user="user",
             device=None,
             priority=0,
             expire=None,
             retry=None,
+            sound=None,
             token=None,
         )


### PR DESCRIPTION
### What does this PR do?
Cleans up a lot of code, essentially a rewrite based on the previous logic. This is a breaking change in several ways. Most importantly: Changes `pushover.post_message` parameter order, making the (required) `message` the first positional parameter.

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-pushover/issues/20
Fixes: https://github.com/salt-extensions/saltext-pushover/issues/21
Fixes: https://github.com/salt-extensions/saltext-pushover/issues/22

### Previous Behavior
* Unnecessarily complex and duplicated code, also in consumers
* Unnecessary server validation of inputs during each message submission, adding 1 or 2 requests
* Confusion in parameters (some are ignored, some have defaults but are actually required)

### New Behavior
* More straightforward code, better result communication, arbitrary queries
* 1 request per message submission instead of 2/3
* Parameter order makes sense. All parameters are respected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [x] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes